### PR TITLE
Expose authority pseudo-header in ObjC lib.

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.h
+++ b/src/objective-c/GRPCClient/GRPCCall.h
@@ -179,9 +179,9 @@ extern id const kGRPCTrailersKey;
 @interface GRPCCall : GRXWriter
 
 /**
- * Authority pseudo-header value.
+ * The server name for the RPC. If nil, the host name of the service object will be used instead.
  */
-@property (atomic, readwrite) NSString *authority;
+@property (atomic, readwrite) NSString *serverName;
 
 /**
  * The container of the request headers of an RPC conforms to this protocol, which is a subset of

--- a/src/objective-c/GRPCClient/GRPCCall.h
+++ b/src/objective-c/GRPCClient/GRPCCall.h
@@ -179,6 +179,11 @@ extern id const kGRPCTrailersKey;
 @interface GRPCCall : GRXWriter
 
 /**
+ * Authority pseudo-header value.
+ */
+@property (atomic, readwrite) NSString *authority;
+
+/**
  * The container of the request headers of an RPC conforms to this protocol, which is a subset of
  * NSMutableDictionary's interface. It will become a NSMutableDictionary later on.
  * The keys of this container are the header names, which per the HTTP standard are case-

--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -426,7 +426,7 @@ static NSMutableDictionary *callFlags;
 
   _responseWriteable = [[GRXConcurrentWriteable alloc] initWithWriteable:writeable];
 
-  _wrappedCall = [[GRPCWrappedCall alloc] initWithHost:_host authority:_authority path:_path];
+  _wrappedCall = [[GRPCWrappedCall alloc] initWithHost:_host serverName:_serverName path:_path];
   NSAssert(_wrappedCall, @"Error allocating RPC objects. Low memory?");
 
   [self sendHeaders:_requestHeaders];

--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -426,7 +426,7 @@ static NSMutableDictionary *callFlags;
 
   _responseWriteable = [[GRXConcurrentWriteable alloc] initWithWriteable:writeable];
 
-  _wrappedCall = [[GRPCWrappedCall alloc] initWithHost:_host path:_path];
+  _wrappedCall = [[GRPCWrappedCall alloc] initWithHost:_host authority:_authority path:_path];
   NSAssert(_wrappedCall, @"Error allocating RPC objects. Low memory?");
 
   [self sendHeaders:_requestHeaders];

--- a/src/objective-c/GRPCClient/private/GRPCChannel.h
+++ b/src/objective-c/GRPCClient/private/GRPCChannel.h
@@ -77,6 +77,6 @@ struct grpc_channel_credentials;
                                      channelArgs:(nullable NSDictionary *)channelArgs;
 
 - (nullable grpc_call *)unmanagedCallWithPath:(nonnull NSString *)path
-                                    authority:(nonnull NSString *)authority
+								   serverName:(nonnull NSString *)serverName
                               completionQueue:(nonnull GRPCCompletionQueue *)queue;
 @end

--- a/src/objective-c/GRPCClient/private/GRPCChannel.h
+++ b/src/objective-c/GRPCClient/private/GRPCChannel.h
@@ -77,5 +77,6 @@ struct grpc_channel_credentials;
                                      channelArgs:(nullable NSDictionary *)channelArgs;
 
 - (nullable grpc_call *)unmanagedCallWithPath:(nonnull NSString *)path
+                                    authority:(nonnull NSString *)authority
                               completionQueue:(nonnull GRPCCompletionQueue *)queue;
 @end

--- a/src/objective-c/GRPCClient/private/GRPCChannel.h
+++ b/src/objective-c/GRPCClient/private/GRPCChannel.h
@@ -77,6 +77,6 @@ struct grpc_channel_credentials;
                                      channelArgs:(nullable NSDictionary *)channelArgs;
 
 - (nullable grpc_call *)unmanagedCallWithPath:(nonnull NSString *)path
-								   serverName:(nonnull NSString *)serverName
+                                   serverName:(nonnull NSString *)serverName
                               completionQueue:(nonnull GRPCCompletionQueue *)queue;
 @end

--- a/src/objective-c/GRPCClient/private/GRPCChannel.m
+++ b/src/objective-c/GRPCClient/private/GRPCChannel.m
@@ -196,7 +196,7 @@ static grpc_channel_args *BuildChannelArgs(NSDictionary *dictionary) {
 }
 
 - (grpc_call *)unmanagedCallWithPath:(NSString *)path
-						  serverName:(NSString *)serverName
+                          serverName:(NSString *)serverName
                      completionQueue:(GRPCCompletionQueue *)queue {
   grpc_slice host = grpc_slice_from_copied_string(serverName.UTF8String);
   return grpc_channel_create_call(_unmanagedChannel,

--- a/src/objective-c/GRPCClient/private/GRPCChannel.m
+++ b/src/objective-c/GRPCClient/private/GRPCChannel.m
@@ -196,12 +196,14 @@ static grpc_channel_args *BuildChannelArgs(NSDictionary *dictionary) {
 }
 
 - (grpc_call *)unmanagedCallWithPath:(NSString *)path
+                           authority:(NSString *)authority
                      completionQueue:(GRPCCompletionQueue *)queue {
+  grpc_slice host = grpc_slice_from_copied_string(authority.UTF8String);
   return grpc_channel_create_call(_unmanagedChannel,
                                   NULL, GRPC_PROPAGATE_DEFAULTS,
                                   queue.unmanagedQueue,
                                   grpc_slice_from_copied_string(path.UTF8String),
-                                  NULL, // Passing NULL for host
+                                  &host,
                                   gpr_inf_future(GPR_CLOCK_REALTIME), NULL);
 }
 

--- a/src/objective-c/GRPCClient/private/GRPCChannel.m
+++ b/src/objective-c/GRPCClient/private/GRPCChannel.m
@@ -196,9 +196,9 @@ static grpc_channel_args *BuildChannelArgs(NSDictionary *dictionary) {
 }
 
 - (grpc_call *)unmanagedCallWithPath:(NSString *)path
-                           authority:(NSString *)authority
+						  serverName:(NSString *)serverName
                      completionQueue:(GRPCCompletionQueue *)queue {
-  grpc_slice host = grpc_slice_from_copied_string(authority.UTF8String);
+  grpc_slice host = grpc_slice_from_copied_string(serverName.UTF8String);
   return grpc_channel_create_call(_unmanagedChannel,
                                   NULL, GRPC_PROPAGATE_DEFAULTS,
                                   queue.unmanagedQueue,

--- a/src/objective-c/GRPCClient/private/GRPCHost.h
+++ b/src/objective-c/GRPCClient/private/GRPCHost.h
@@ -69,6 +69,7 @@ struct grpc_channel_credentials;
 
 /** Create a grpc_call object to the provided path on this host. */
 - (nullable struct grpc_call *)unmanagedCallWithPath:(NSString *)path
+                                           authority:(nullable NSString *)authority
                                      completionQueue:(GRPCCompletionQueue *)queue;
 
 // TODO: There's a race when a new RPC is coming through just as an existing one is getting

--- a/src/objective-c/GRPCClient/private/GRPCHost.h
+++ b/src/objective-c/GRPCClient/private/GRPCHost.h
@@ -69,7 +69,7 @@ struct grpc_channel_credentials;
 
 /** Create a grpc_call object to the provided path on this host. */
 - (nullable struct grpc_call *)unmanagedCallWithPath:(NSString *)path
-                                           authority:(nullable NSString *)authority
+										  serverName:(nullable NSString *)serverName
                                      completionQueue:(GRPCCompletionQueue *)queue;
 
 // TODO: There's a race when a new RPC is coming through just as an existing one is getting

--- a/src/objective-c/GRPCClient/private/GRPCHost.h
+++ b/src/objective-c/GRPCClient/private/GRPCHost.h
@@ -69,7 +69,7 @@ struct grpc_channel_credentials;
 
 /** Create a grpc_call object to the provided path on this host. */
 - (nullable struct grpc_call *)unmanagedCallWithPath:(NSString *)path
-										  serverName:(nullable NSString *)serverName
+                                          serverName:(nullable NSString *)serverName
                                      completionQueue:(GRPCCompletionQueue *)queue;
 
 // TODO: There's a race when a new RPC is coming through just as an existing one is getting

--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -135,6 +135,7 @@ static GRPCConnectivityMonitor *connectivityMonitor = nil;
 }
 
 - (nullable grpc_call *)unmanagedCallWithPath:(NSString *)path
+                                    authority:(nullable NSString *)authority
                               completionQueue:(GRPCCompletionQueue *)queue {
   GRPCChannel *channel;
   // This is racing -[GRPCHost disconnect].
@@ -144,7 +145,8 @@ static GRPCConnectivityMonitor *connectivityMonitor = nil;
     }
     channel = _channel;
   }
-  return [channel unmanagedCallWithPath:path completionQueue:queue];
+  NSString *callAuthority = authority ? authority : _address;
+  return [channel unmanagedCallWithPath:path authority:callAuthority completionQueue:queue];
 }
 
 - (BOOL)setTLSPEMRootCerts:(nullable NSString *)pemRootCerts

--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -135,7 +135,7 @@ static GRPCConnectivityMonitor *connectivityMonitor = nil;
 }
 
 - (nullable grpc_call *)unmanagedCallWithPath:(NSString *)path
-								   serverName:(nullable NSString *)serverName
+                                   serverName:(nullable NSString *)serverName
                               completionQueue:(GRPCCompletionQueue *)queue {
   GRPCChannel *channel;
   // This is racing -[GRPCHost disconnect].

--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -135,7 +135,7 @@ static GRPCConnectivityMonitor *connectivityMonitor = nil;
 }
 
 - (nullable grpc_call *)unmanagedCallWithPath:(NSString *)path
-                                    authority:(nullable NSString *)authority
+								   serverName:(nullable NSString *)serverName
                               completionQueue:(GRPCCompletionQueue *)queue {
   GRPCChannel *channel;
   // This is racing -[GRPCHost disconnect].
@@ -145,8 +145,8 @@ static GRPCConnectivityMonitor *connectivityMonitor = nil;
     }
     channel = _channel;
   }
-  NSString *callAuthority = authority ? authority : _address;
-  return [channel unmanagedCallWithPath:path authority:callAuthority completionQueue:queue];
+  NSString *name = serverName ? serverName : _address;
+  return [channel unmanagedCallWithPath:path serverName:name completionQueue:queue];
 }
 
 - (BOOL)setTLSPEMRootCerts:(nullable NSString *)pemRootCerts

--- a/src/objective-c/GRPCClient/private/GRPCWrappedCall.h
+++ b/src/objective-c/GRPCClient/private/GRPCWrappedCall.h
@@ -90,6 +90,7 @@
 @interface GRPCWrappedCall : NSObject
 
 - (instancetype)initWithHost:(NSString *)host
+                   authority:(nullable NSString *)authority
                         path:(NSString *)path NS_DESIGNATED_INITIALIZER;
 
 - (void)startBatchWithOperations:(NSArray *)ops errorHandler:(void(^)())errorHandler;

--- a/src/objective-c/GRPCClient/private/GRPCWrappedCall.h
+++ b/src/objective-c/GRPCClient/private/GRPCWrappedCall.h
@@ -90,7 +90,7 @@
 @interface GRPCWrappedCall : NSObject
 
 - (instancetype)initWithHost:(NSString *)host
-                   authority:(nullable NSString *)authority
+				  serverName:(nullable NSString *)serverName
                         path:(NSString *)path NS_DESIGNATED_INITIALIZER;
 
 - (void)startBatchWithOperations:(NSArray *)ops errorHandler:(void(^)())errorHandler;

--- a/src/objective-c/GRPCClient/private/GRPCWrappedCall.h
+++ b/src/objective-c/GRPCClient/private/GRPCWrappedCall.h
@@ -90,7 +90,7 @@
 @interface GRPCWrappedCall : NSObject
 
 - (instancetype)initWithHost:(NSString *)host
-				  serverName:(nullable NSString *)serverName
+                  serverName:(nullable NSString *)serverName
                         path:(NSString *)path NS_DESIGNATED_INITIALIZER;
 
 - (void)startBatchWithOperations:(NSArray *)ops errorHandler:(void(^)())errorHandler;

--- a/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
+++ b/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
@@ -251,7 +251,7 @@
 }
 
 - (instancetype)initWithHost:(NSString *)host
-				  serverName:(nullable NSString *)serverName
+                  serverName:(nullable NSString *)serverName
                         path:(NSString *)path {
   if (!path || !host) {
     [NSException raise:NSInvalidArgumentException

--- a/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
+++ b/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
@@ -247,10 +247,11 @@
 }
 
 - (instancetype)init {
-  return [self initWithHost:nil path:nil];
+  return [self initWithHost:nil authority:nil path:nil];
 }
 
 - (instancetype)initWithHost:(NSString *)host
+                   authority:(nullable NSString *)authority
                         path:(NSString *)path {
   if (!path || !host) {
     [NSException raise:NSInvalidArgumentException
@@ -263,7 +264,7 @@
     // queue. Currently we use a singleton queue.
     _queue = [GRPCCompletionQueue completionQueue];
 
-    _call = [[GRPCHost hostWithAddress:host] unmanagedCallWithPath:path completionQueue:_queue];
+    _call = [[GRPCHost hostWithAddress:host] unmanagedCallWithPath:path authority:authority completionQueue:_queue];
     if (_call == NULL) {
       return nil;
     }

--- a/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
+++ b/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
@@ -247,11 +247,11 @@
 }
 
 - (instancetype)init {
-  return [self initWithHost:nil authority:nil path:nil];
+  return [self initWithHost:nil serverName:nil path:nil];
 }
 
 - (instancetype)initWithHost:(NSString *)host
-                   authority:(nullable NSString *)authority
+				  serverName:(nullable NSString *)serverName
                         path:(NSString *)path {
   if (!path || !host) {
     [NSException raise:NSInvalidArgumentException
@@ -264,7 +264,7 @@
     // queue. Currently we use a singleton queue.
     _queue = [GRPCCompletionQueue completionQueue];
 
-    _call = [[GRPCHost hostWithAddress:host] unmanagedCallWithPath:path authority:authority completionQueue:_queue];
+    _call = [[GRPCHost hostWithAddress:host] unmanagedCallWithPath:path serverName:serverName completionQueue:_queue];
     if (_call == NULL) {
       return nil;
     }


### PR DESCRIPTION
This exposes the `authority` pseudo-header value to gRPC calls in ObjC. They haven't built this feature yet but have mentioned they might eventually add it (https://github.com/grpc/grpc/pull/10858)